### PR TITLE
Hotfix: Fix exp ID generation and improve summarization log readability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: minutemaker
 Title: GenAI-based meeting and conferences minutes generator
-Version: 0.5.3
+Version: 0.5.4
 Authors@R: 
     person("Angelo", "D'Ambrosio", , "a.dambrosioMD@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2045-5155"))

--- a/R/summarization.R
+++ b/R/summarization.R
@@ -386,7 +386,7 @@ summarise_full_meeting <- function(
       next
     }
 
-    message("Talk: ", id)
+    message("\n# Talk: ", id)
 
     # Get the index of the current talk in the agenda
     i <- which(talks_ids == id)

--- a/R/validation.R
+++ b/R/validation.R
@@ -93,16 +93,8 @@ check_summary_tree_consistency <- function(summary_tree) {
 
   obs_ids <- names(summary_tree)
 
-  titles <- purrr::map(summary_tree, \(x) x[["title"]])
-  sessions <- purrr::map(summary_tree, \(x) {
-    if (!purrr::is_empty(x[["session"]])) {
-      x[["session"]]
-    } else {
-      x[["title"]]
-    }
-  })
-
-  exp_ids <- paste(sessions, titles, sep = "_")
+  exp_ids <- build_ids_from_agenda(summary_tree)
+  names(exp_ids) <- NULL
 
   test <- all.equal(obs_ids, exp_ids)
 
@@ -110,7 +102,8 @@ check_summary_tree_consistency <- function(summary_tree) {
     return()
   }
 
-  stop("The summary tree is not consistent: ", test, ".\n",
+  stop("The summary tree IDs and titles/sessions are not consistent: ",
+       test, ".\n",
        purrr::map(seq_along(obs_ids), \(i) {
          if (obs_ids[i] != exp_ids[i]) {
            sprintf('"%s" != "%s"', obs_ids[i], exp_ids[i])


### PR DESCRIPTION
This pull request includes two commits:

1. fix: fix exp ID generation in summary tree check

2. feat: improve summarization log readability

The first commit fixes the generation of experiment IDs in the summary tree check. It ensures that the IDs are correctly generated and consistent with the titles and sessions. The previous version was causing an error when session where not used in the agenda definition.

The second commit improves the readability of the summarization log. It separates different summarised talks in the log for better clarity.

These changes enhance the functionality and user experience of the software.